### PR TITLE
Bring deps back to dev 2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 
 {deps, [
        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
-       {riak_core, ".*", {git, "git://github.com/nhs-riak/riak_core.git", {branch, "rdb/2.1.9-nhs-2.2.5"}}},
+       {riak_core, ".*", {git, "git://github.com/nhs-riak/riak_core.git", {branch, "develop-2.2"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 
 {deps, [
        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
-       {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.9"}}},
+       {riak_core, ".*", {git, "git://github.com/nhs-riak/riak_core.git", {branch, "rdb/2.1.9-nhs-2.2.5"}}},
        {erlydtl, ".*", {git, "git://github.com/erlydtl/erlydtl.git", "d20b53f0"}}
        ]}.
 


### PR DESCRIPTION
As part of setting up for the 2.2.5 release I made a temp branch off the
last released tag, this takes that branch back into the branch the tag
was cut from.